### PR TITLE
[Web] Fix socket controller and flush database when server starts 

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,11 +2,15 @@ import express from 'express';
 import loader from './loaders';
 import http from 'http';
 
-const app = express();
-const server = http.createServer(app);
-loader(app, server);
+const startServer = async () => {
+  const app = express();
+  const server = http.createServer(app);
+  await loader(app, server);
 
-const { SERVER_PORT } = process.env;
-server.listen(SERVER_PORT, () => {
-  console.log(`Express App Init in ${SERVER_PORT}!`);
-});
+  const { SERVER_PORT } = process.env;
+  server.listen(SERVER_PORT, () => {
+    console.log(`Express App Init in ${SERVER_PORT}!`);
+  });
+};
+
+startServer();

--- a/server/src/loaders/database.ts
+++ b/server/src/loaders/database.ts
@@ -1,0 +1,14 @@
+import client from '../models/redisConnection';
+import roomInfoModel from '../models/roomInfoModel';
+import roomSocketsInfoModel from '../models/roomSocketsInfoModel';
+import socketRoomModel from '../models/socketRoomModel';
+
+const databaseLoader = async () => {
+  try {
+    await roomInfoModel.flushAll();
+    await roomSocketsInfoModel.flushAll();
+    await socketRoomModel.flushAll();
+  } catch (err) {}
+};
+
+export default databaseLoader;

--- a/server/src/loaders/index.ts
+++ b/server/src/loaders/index.ts
@@ -2,12 +2,14 @@ import express from 'express';
 import envLoader from './env';
 import expressLoader from './express';
 import socketLoader from '../socket/socket';
+import databaseLoader from './database';
 import http from 'http';
 
-export default (expressApp: express.Application, server: http.Server): void => {
+export default async (expressApp: express.Application, server: http.Server): Promise<void> => {
   envLoader();
   expressLoader(expressApp);
   socketLoader(server);
+  await databaseLoader();
 
   console.log('✌️ Express loaded');
 };

--- a/server/src/models/roomInfoModel.ts
+++ b/server/src/models/roomInfoModel.ts
@@ -81,6 +81,17 @@ const getTitle = (roomCode: string) => {
   });
 };
 
+const flushAll = () => {
+  return new Promise<string>((resolve, reject) => {
+    client.select(Database.ROOM_INFO, () => {
+      client.flushall((err, res) => {
+        if (err) return reject(err);
+        return resolve(res);
+      });
+    });
+  });
+};
+
 const roomInfoModel = {
   removeRoom,
   getRoomCodeList,
@@ -89,6 +100,7 @@ const roomInfoModel = {
   setRoom,
   isRoomPrivate,
   getTitle,
+  flushAll,
 };
 
 export default roomInfoModel;

--- a/server/src/models/roomSocketsInfoModel.ts
+++ b/server/src/models/roomSocketsInfoModel.ts
@@ -57,6 +57,17 @@ const getSocketCountByRoom = (roomCode: string) => {
   });
 };
 
+const getSocketInfo = (roomCode: string, socketId: string) => {
+  return new Promise<string>((resolve, reject) => {
+    client.select(Database.ROOM_SOCKETS_INFO, () => {
+      client.hget(roomCode, socketId, (err, res) => {
+        if (err) return reject(err);
+        return resolve(res);
+      });
+    });
+  });
+};
+
 const flushAll = () => {
   return new Promise<string>((resolve, reject) => {
     client.select(Database.ROOM_SOCKETS_INFO, () => {
@@ -74,6 +85,7 @@ const roomSocketsInfoModel = {
   removeSocketByRoom,
   isRoomEmpty,
   getSocketCountByRoom,
+  getSocketInfo,
   flushAll,
 };
 

--- a/server/src/models/roomSocketsInfoModel.ts
+++ b/server/src/models/roomSocketsInfoModel.ts
@@ -57,12 +57,24 @@ const getSocketCountByRoom = (roomCode: string) => {
   });
 };
 
+const flushAll = () => {
+  return new Promise<string>((resolve, reject) => {
+    client.select(Database.ROOM_SOCKETS_INFO, () => {
+      client.flushall((err, res) => {
+        if (err) return reject(err);
+        return resolve(res);
+      });
+    });
+  });
+};
+
 const roomSocketsInfoModel = {
   setSocketInfo,
   getSocketsByRoom,
   removeSocketByRoom,
   isRoomEmpty,
   getSocketCountByRoom,
+  flushAll,
 };
 
 export default roomSocketsInfoModel;

--- a/server/src/models/socketRoomModel.ts
+++ b/server/src/models/socketRoomModel.ts
@@ -34,10 +34,22 @@ const removeSocket = (socketId: string) => {
   });
 };
 
+const flushAll = () => {
+  return new Promise<string>((resolve, reject) => {
+    client.select(Database.SOCKET_ROOM, () => {
+      client.flushall((err, res) => {
+        if (err) return reject(err);
+        return resolve(res);
+      });
+    });
+  });
+};
+
 const socketRoomModel = {
   setRoomBySocket,
   getRoomBySocket,
   removeSocket,
+  flushAll,
 };
 
 export default socketRoomModel;

--- a/server/src/socket/socket.ts
+++ b/server/src/socket/socket.ts
@@ -24,7 +24,9 @@ const socketLoader = (server: http.Server) => {
       socketControllers.disconnect(socket, io);
     });
 
-    // socket.on('leave chatroom')
+    socket.on('leave chatroom', () => {
+      socketControllers.disconnect(socket, io);
+    });
   });
 };
 

--- a/server/src/socket/socketController.ts
+++ b/server/src/socket/socketController.ts
@@ -6,6 +6,7 @@ import {
   receiveChatType,
 } from '../types/socketTypes';
 import SocketIO, { Socket } from 'socket.io';
+import moment from 'moment';
 import roomInfoModel from '../models/roomInfoModel';
 import roomSocketsInfoModel from '../models/roomSocketsInfoModel';
 import socketRoomModel from '../models/socketRoomModel';
@@ -41,6 +42,7 @@ const sendChat = async (socket: Socket, io: SocketIO.Server, sendChat: sendChatT
     English,
     senderId: socket.id,
     nickname,
+    createdAt: moment().format('YYYY-MM-DD HH:mm:ss'),
   };
   io.to(roomCode).emit('receive chat', receiveChat);
 };

--- a/server/src/socket/socketController.ts
+++ b/server/src/socket/socketController.ts
@@ -13,7 +13,6 @@ import socketRoomModel from '../models/socketRoomModel';
 const enterChatroom = async (socket: Socket, io: SocketIO.Server, userData: userDataType) => {
   const { roomCode, nickname, language } = userData;
   socket.join(roomCode);
-  // TODO: db1, 2 소켓 정보 저장
   await roomSocketsInfoModel.setSocketInfo(roomCode, socket.id, JSON.stringify({ nickname, language }));
   await socketRoomModel.setRoomBySocket(socket.id, roomCode);
 
@@ -24,7 +23,6 @@ const enterChatroom = async (socket: Socket, io: SocketIO.Server, userData: user
   });
 
   const renewedParticipants: participantsListType = {
-    // TODO: 참가자 리스트 가져와서 넣어주기
     participantsList: participantsList,
     type: 'enter',
   };
@@ -33,19 +31,30 @@ const enterChatroom = async (socket: Socket, io: SocketIO.Server, userData: user
 
 const sendChat = async (socket: Socket, io: SocketIO.Server, sendChat: sendChatType) => {
   const { Korean, English } = sendChat;
+  const roomCode = await socketRoomModel.getRoomBySocket(socket.id);
+
+  const socketInfo = await roomSocketsInfoModel.getSocketInfo(roomCode, socket.id);
+  const { nickname }: { nickname: string } = JSON.parse(socketInfo);
+
   const receiveChat: receiveChatType = {
     Korean,
     English,
     senderId: socket.id,
+    nickname,
   };
-  // TODO: 현재 소켓이 속해있는 방 id 받아오기
-  const roomCode: string = await socketRoomModel.getRoomBySocket(socket.id); // db를 통해 받아오기
   io.to(roomCode).emit('receive chat', receiveChat);
 };
 
 const disconnect = async (socket: Socket, io: SocketIO.Server) => {
-  // TODO: 현재 소켓이 속해있는 방 id 받아오기
-  const roomCode: string = await socketRoomModel.getRoomBySocket(socket.id); // db를 통해 받아오기
+  const roomCode: string = await socketRoomModel.getRoomBySocket(socket.id);
+
+  await roomSocketsInfoModel.removeSocketByRoom(roomCode, socket.id);
+  await socketRoomModel.removeSocket(socket.id);
+
+  if (await roomSocketsInfoModel.isRoomEmpty(roomCode)) {
+    await roomInfoModel.removeRoom(roomCode);
+    return;
+  }
 
   const rawParticipantsData = await roomSocketsInfoModel.getSocketsByRoom(roomCode);
   const participantsList: participantsType[] = Object.entries(rawParticipantsData).map(([key, value]) => {
@@ -54,18 +63,10 @@ const disconnect = async (socket: Socket, io: SocketIO.Server) => {
   });
 
   const renewedParticipants: participantsListType = {
-    // TODO: 참가자 리스트 가져와서 넣어주기
     participantsList: participantsList,
     type: 'leave',
   };
   io.to(roomCode).emit('receive participants list', renewedParticipants);
-  // TODO: 소켓을 DB 1, 2번에서 제거
-  await roomSocketsInfoModel.removeSocketByRoom(roomCode, socket.id);
-  await socketRoomModel.removeSocket(socket.id);
-  // TODO: 방이 비었는지 확인하고 비었으면 0번에서 해당 방 제거
-  if (await roomSocketsInfoModel.isRoomEmpty(roomCode)) {
-    await roomInfoModel.removeRoom(roomCode);
-  }
 };
 
 const socketControllers = {

--- a/server/src/types/socketTypes.ts
+++ b/server/src/types/socketTypes.ts
@@ -24,6 +24,7 @@ type receiveChatType = {
   Korean: string;
   English: string;
   senderId: string;
+  nickname: string;
 };
 
 type roomInfoType = {
@@ -55,4 +56,5 @@ export {
   roomInfoType,
   roomListType,
   createdRoomType,
+  participantsType,
 };

--- a/server/src/types/socketTypes.ts
+++ b/server/src/types/socketTypes.ts
@@ -25,6 +25,7 @@ type receiveChatType = {
   English: string;
   senderId: string;
   nickname: string;
+  createdAt: string;
 };
 
 type roomInfoType = {


### PR DESCRIPTION
### 🍞 Issue Number 

close: #49 
<br/>

### 🥞 작업 내역

> 구현 내용 및 작업 했던 내역

- [ ] 서버가 재시작할 때 데이터베이스를 초기화.
- [ ] leave chatroom 이벤트 발생 시, 서버에서는 disconnect 이벤트 발생과 동일한 로직이 실행.
- [ ] 하나의 소켓의 정보가 담긴 문자열을 반환하는 함수 추가.
- [ ] 메시지 작성자의 nickname을 추가하여 전송.
- [ ] 참가자 목록을 갱신하기 전, 방이 비었다면 바로 함수 반환(종료).
- [ ] 메시지를 전달할 때, 작성 시각을 함께 추가하여 클라이언트에 전달.

<br/>

### 🍞 새로운 기능

- 하나의 소켓의 정보가 담긴 문자열을 반환하는 함수 추가.
<br/>

### 🍞 작업 유형

- [X] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
  <br/>

### 🥞 체크리스트

- [X] Merge 하는 브랜치가 올바른가?
- [X] 코딩컨벤션을 준수하는가?
- [X] PR과 관련없는 변경사항이 없는가?
- [X] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
  <br/>
