### PR TITLE
[Web]  Stop changing profile Photo when come back to user ProfilePage 

### DIFF
--- a/client/src/components/organisms/userInfoPage/ProfilePictureSelection.tsx
+++ b/client/src/components/organisms/userInfoPage/ProfilePictureSelection.tsx
@@ -6,7 +6,9 @@ function ProfilePictureSelection() {
   const { imageLinkData, onGetRandomProfileImage } = useUser();
 
   useEffect(() => {
-    onGetRandomProfileImage();
+    if (!imageLinkData) {
+      onGetRandomProfileImage();
+    }
   }, []);
 
   return <ProfilePictureSelectionMolecule image={imageLinkData!} onClickRefresh={onGetRandomProfileImage} />;


### PR DESCRIPTION
### 🍞 Issue Number 

close: #341
<br/>

### 🥞 작업 내역

> 구현 내용 및 작업 했던 내역

- [ ] 방 나가기 버튼 클릭 시 유저 정보 빼고 다 초기화 시켰는데 프로필 사진은 변경되는 버그 해결



### 🍞 새로운 기능

- 방 나가기 버튼 클릭 시 유저 정보 빼고 다 초기화 시켰는데 프로필 사진은 변경되는 버그 해결
  <br/>

### 🍞 작업 유형

- [ ] 신규 기능 추가
- [X] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
  <br/>

### 🥞 체크리스트

- [X] Merge 하는 브랜치가 올바른가?
- [X] 코딩컨벤션을 준수하는가?
- [X] PR과 관련없는 변경사항이 없는가?
- [X] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
  <br/>



<br/><br/>
