### PR TITLE
[Web] Disable redux-devtools when production

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -3,15 +3,19 @@ import ReactDOM from 'react-dom';
 import Thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { applyMiddleware, createStore } from 'redux';
-import { composeWithDevTools } from 'redux-devtools-extension';
 import { Router } from 'react-router';
 import { createBrowserHistory } from 'history';
 
 import App from './App';
 import rootReducer from './modules';
+import { composeWithDevTools } from 'redux-devtools-extension';
 
 export const history = createBrowserHistory();
-const store = createStore(rootReducer, composeWithDevTools(applyMiddleware(Thunk)));
+
+const store = createStore(
+  rootReducer,
+  process.env.NODE_ENV === 'production' ? applyMiddleware(Thunk) : composeWithDevTools(applyMiddleware(Thunk)),
+);
 
 ReactDOM.render(
   <Router history={history}>


### PR DESCRIPTION

### 🍞 Issue Number 

close: #460
<br/>

### 🥞 작업 내역

> 구현 내용 및 작업 했던 내역

- [ ] Redux-devtools를 production 모드일때는 비활성화 하게 만들었다.



### 🍞 새로운 기능

- Redux-devtools를 production 모드일때는 비활성화 
  <br/>

### 🍞 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
  <br/>

### 🥞 체크리스트

- [X] Merge 하는 브랜치가 올바른가?
- [X] 코딩컨벤션을 준수하는가?
- [X] PR과 관련없는 변경사항이 없는가?
- [X] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
  <br/>
